### PR TITLE
Add utility that indicates whether we're in "Test Mode"

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { AuthSession, FileSystem, Constants } from 'expo'
 import jwtDecode from 'jwt-decode'
 import config from '../../config.json'
-import { getMSAuthUrl } from '../utils'
+import { getMSAuthUrl, isTestMode } from '../utils'
 import { idTokenFileUri } from '../../constants/FileSystem'
 import { setToken, hideModal } from '../actions'
 
@@ -41,12 +41,14 @@ class Login extends React.Component {
 
   render() {
     const { fakeLogin } = this.props
-    const { appOwnership } = Constants
-    const isDev = appOwnership === 'expo' || Constants.manifest.name.includes('Local Testing')
     return (
       <View>
         <Button title="Log in with Microsoft" onPress={this.handleMSLoginPress} />
-        { isDev ? <Button testID="hero_login" title="Log in as a hero" onPress={fakeLogin} /> : null }
+        {
+          isTestMode() ?
+            <Button testID="hero_login" title="Log in as test user" onPress={fakeLogin} /> :
+            null
+        }
       </View>
     )
   }

--- a/src/utils/__mocks__/expo.js
+++ b/src/utils/__mocks__/expo.js
@@ -1,0 +1,10 @@
+const expoScaffold = {
+  Constants: {
+    appOwnership: '',
+    manifest: {
+      name: '',
+    },
+  },
+}
+
+module.exports = expoScaffold

--- a/src/utils/__tests__/isTestMode-test.js
+++ b/src/utils/__tests__/isTestMode-test.js
@@ -1,0 +1,22 @@
+import { Constants } from 'expo'
+import { isTestMode } from '../index'
+
+describe('Test mode indicator', () => {
+  test('returns true when Expo is running the app AND app is using the local testing configuration', () => {
+    Constants.appOwnership = 'expo'
+    Constants.manifest.name = 'Who cares what this says, because we only care about this --> Local Testing'
+    expect(isTestMode()).toBe(true)
+  })
+
+  test('returns false when the app is built in Expo "standalone" mode', () => {
+    Constants.appOwnership = 'standalone'
+    Constants.manifest.name = 'Local Testing'
+    expect(isTestMode()).toBe(false)
+  })
+
+  test('returns false when running with the production configuration', () => {
+    Constants.appOwnership = 'expo'
+    Constants.manifest.name = 'Bookit Mobile'
+    expect(isTestMode()).toBe(false)
+  })
+})

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon'
+import { Constants } from 'expo'
 
 export const getBookableNameFromId =
   (bookableId, bookablesArray) => bookablesArray.reduce((result, current) => (
@@ -21,14 +22,6 @@ export const formatDate =
     DateTime.fromISO(date, { zone: zoneName }).toLocaleString(DateTime.DATETIME_FULL)
   )
 
-/* ============== MS Auth Notes from Bookit Web ==============
-
-See:
-  `utils/azure`
-  `utils/auth`
-  `redux/auth`
-
-=============================== */
 export const getMSAuthUrl = (options, redirectUrl) => (
   'https://login.microsoftonline.com/common/oauth2/v2.0/authorize' +
     `?client_id=${options.clientId}` +
@@ -41,3 +34,9 @@ export const getMSAuthUrl = (options, redirectUrl) => (
     `&prompt=${options.prompt}` +
     `&login_hint=${options.loginHint}`
 )
+
+export const isTestMode = () => {
+  const appIsRunningInExpo = Constants.appOwnership === 'expo'
+  const appIsUsingTestConfig = Constants.manifest.name.includes('Local Testing')
+  return appIsRunningInExpo && appIsUsingTestConfig
+}


### PR DESCRIPTION
Resolves #20

This commit adds a new utility, `isTestMode`, that returns true when Expo is running the app AND app is using the local testing configuration.

To validate, run the app using the local testing configuration:
`exp start -c -i --config ./local-testing.json`

You should see a button allowing you to log in as a test user on the "Me" screen.

Then run the app using the production configuration:
`exp start -c -i --config ./app.json`

The test user login button should not be visible.