### PR TITLE
Add a spot where user can view info about the app

### DIFF
--- a/App.js
+++ b/App.js
@@ -24,7 +24,7 @@ const store = createStore(
   root,
   applyMiddleware(
     thunk,
-    // naiveLogger,
+    naiveLogger,
   ),
 )
 

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, View } from 'react-native'
+import { Button, View, StyleSheet } from 'react-native'
 import { connect } from 'react-redux'
 import { AuthSession, FileSystem, Constants } from 'expo'
 import jwtDecode from 'jwt-decode'
@@ -53,7 +53,7 @@ class Login extends React.Component {
   render() {
     const { fakeLogin } = this.props
     return (
-      <View>
+      <View style={styles.container}>
         <Button title="Log in with Microsoft" onPress={this.handleMSLoginPress} />
         {
           isTestMode() ?
@@ -81,3 +81,11 @@ const mapDispatchToProps = dispatch => ({
 })
 
 export default connect(null, mapDispatchToProps)(Login)
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+})

--- a/src/components/PickerButton.js
+++ b/src/components/PickerButton.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { StyleSheet, View, TouchableHighlight, Text } from 'react-native'
+import { LabelText } from './StyledText'
 import colors from '../../constants/Colors'
 
 const PickerButton = ({
@@ -9,7 +10,7 @@ const PickerButton = ({
   unitsLabel,
 }) => (
   <View style={styles.button}>
-    <Text style={styles.label}>{label}</Text>
+    <LabelText style={styles.label}>{label}</LabelText>
     <TouchableHighlight onPress={onPress}>
       <Text style={styles.value}>{unitsLabel ? `${value} ${unitsLabel}` : value}</Text>
     </TouchableHighlight>
@@ -26,7 +27,6 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
   },
   label: {
-    color: '#555555',
     width: 60,
   },
   value: {

--- a/src/components/StyledText.js
+++ b/src/components/StyledText.js
@@ -15,3 +15,12 @@ export const ShoutyText = props => (
     }]}
   />
 )
+
+export const LabelText = props => (
+  <Text
+    {...props}
+    style={[props.style, {
+      color: '#555555',
+    }]}
+  />
+)

--- a/src/components/__tests__/StyledText-test.js
+++ b/src/components/__tests__/StyledText-test.js
@@ -2,10 +2,24 @@ import 'react-native'
 import React from 'react'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import renderer from 'react-test-renderer'
-import { MonoText } from '../StyledText'
+import { MonoText, ShoutyText, LabelText } from '../StyledText'
 
-it('renders correctly', () => {
+it('renders MonoText correctly', () => {
   const tree = renderer.create(<MonoText>Snapshot test!</MonoText>).toJSON()
+  expect(tree).toMatchSnapshot()
+})
 
+it('renders ShoutyText correctly', () => {
+  const tree = renderer.create(<ShoutyText>Snapshot test!</ShoutyText>).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('renders LabelText correctly', () => {
+  const tree = renderer.create(<LabelText>Snapshot test!</LabelText>).toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+it('respects optional styles for LabelText', () => {
+  const tree = renderer.create(<LabelText style={{ color: 'tomato' }}>Snapshot test!</LabelText>).toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/components/__tests__/TechInfoModal-test.js
+++ b/src/components/__tests__/TechInfoModal-test.js
@@ -1,0 +1,13 @@
+import 'react-native'
+import React from 'react'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import renderer from 'react-test-renderer'
+import TechInfoModal from '../modals/TechInfoModal'
+
+it('renders correctly', () => {
+  const tree = renderer.create(<TechInfoModal
+    onOkayPress={() => {}}
+  />).toJSON()
+
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/src/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`renders LabelText correctly 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Array [
+      undefined,
+      Object {
+        "color": "#555555",
+      },
+    ]
+  }
+>
+  Snapshot test!
+</Text>
+`;
+
+exports[`renders MonoText correctly 1`] = `
 <Text
   accessible={true}
   allowFontScaling={true}
@@ -10,6 +28,46 @@ exports[`renders correctly 1`] = `
       undefined,
       Object {
         "fontFamily": "space-mono",
+      },
+    ]
+  }
+>
+  Snapshot test!
+</Text>
+`;
+
+exports[`renders ShoutyText correctly 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Array [
+      undefined,
+      Object {
+        "color": "#555",
+        "fontSize": 32,
+        "marginBottom": 50,
+      },
+    ]
+  }
+>
+  Snapshot test!
+</Text>
+`;
+
+exports[`respects optional styles for LabelText 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Array [
+      Object {
+        "color": "tomato",
+      },
+      Object {
+        "color": "#555555",
       },
     ]
   }

--- a/src/components/__tests__/__snapshots__/TechInfoModal-test.js.snap
+++ b/src/components/__tests__/__snapshots__/TechInfoModal-test.js.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#4F97FF",
+        "fontSize": 30,
+        "fontWeight": "bold",
+        "marginBottom": 50,
+      }
+    }
+  >
+    Technical info
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  />
+  <View
+    style={
+      Object {
+        "marginBottom": 20,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          Object {
+            "color": "#555555",
+          },
+        ]
+      }
+    >
+      Bookit API
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          Object {
+            "fontFamily": "space-mono",
+          },
+        ]
+      }
+    >
+      https://staging-bookit-api.buildit.tools/v1/
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "marginBottom": 20,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          Object {
+            "color": "#555555",
+          },
+        ]
+      }
+    >
+      Nonce
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          Object {
+            "fontFamily": "space-mono",
+          },
+        ]
+      }
+    >
+      Nonce has not been set.
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "marginBottom": 20,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          Object {
+            "color": "#555555",
+          },
+        ]
+      }
+    >
+      Session ID
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          undefined,
+          Object {
+            "fontFamily": "space-mono",
+          },
+        ]
+      }
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "marginTop": 50,
+        "padding": 20,
+      }
+    }
+  >
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hasTVPreferredFocus={undefined}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "transparent",
+          },
+          undefined,
+        ]
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "color": "#4F97FF",
+            "fontSize": 24,
+          }
+        }
+      >
+        Okay
+      </Text>
+    </View>
+  </View>
+</View>
+`;

--- a/src/components/modals/RootModal.js
+++ b/src/components/modals/RootModal.js
@@ -4,6 +4,7 @@ import { Modal, View, StyleSheet } from 'react-native'
 import { hideModal } from '../../actions'
 import BookingSuccessModal from './BookingSuccessModal'
 import ErrorModal from './ErrorModal'
+import TechInfoModal from './TechInfoModal'
 
 const RootModal = ({
   modalType,
@@ -13,6 +14,7 @@ const RootModal = ({
   const MODAL_COMPONENTS = {
     BOOKING_SUCCESS: BookingSuccessModal,
     ERROR: ErrorModal,
+    TECHINFO: TechInfoModal,
   }
 
   if (!modalType) {

--- a/src/components/modals/TechInfoModal.js
+++ b/src/components/modals/TechInfoModal.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { View, StyleSheet } from 'react-native'
+import { Constants } from 'expo'
+import ModalContent from './ModalContent'
+import { LabelText, MonoText } from '../StyledText'
+import config from '../../../config.json'
+
+const TechInfoModal = ({ onOkayPress }) => (
+  <ModalContent
+    title="Technical info"
+    onOkayPress={onOkayPress}
+  >
+    <View style={styles.section}>
+      <LabelText>Bookit API</LabelText>
+      <MonoText>{ config.bookitApiBaseUrl }</MonoText>
+    </View>
+    <View style={styles.section}>
+      <LabelText>Nonce</LabelText>
+      <MonoText>{ config.nonce || 'Nonce has not been set.' }</MonoText>
+    </View>
+    <View style={styles.section}>
+      <LabelText>Session ID</LabelText>
+      <MonoText>{ Constants.sessionId }</MonoText>
+    </View>
+  </ModalContent>
+)
+
+export default TechInfoModal
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: 20,
+  },
+  label: {
+    color: '#555555',
+    width: 60,
+  },
+})

--- a/src/screens/AccountScreen.js
+++ b/src/screens/AccountScreen.js
@@ -1,10 +1,9 @@
 import React from 'react'
-import { Text, View, StyleSheet } from 'react-native'
+import { View, StyleSheet, Button } from 'react-native'
 import { connect } from 'react-redux'
 import Login from '../components/Login'
 import Logout from '../components/Logout'
-import config from '../../config.json'
-
+import { showModal } from '../actions'
 
 class AccountScreen extends React.Component {
   static navigationOptions = {
@@ -12,10 +11,13 @@ class AccountScreen extends React.Component {
   }
 
   render() {
-    const { userExists } = this.props
+    const { userExists, showTechInfo } = this.props
     return (
       <View style={styles.container}>
-        { config.nonce ? <Text testID="nonce" accessibilityLabel="nonce">{ config.nonce }</Text> : null }
+        <Button
+          title="Tech info"
+          onPress={showTechInfo}
+        />
         { userExists ? <Logout /> : <Login /> }
       </View>
     )
@@ -26,7 +28,13 @@ const mapStateToProps = state => ({
   userExists: state.token, // Minimum criteria for existence
 })
 
-export default connect(mapStateToProps)(AccountScreen)
+const mapDispatchToProps = dispatch => ({
+  showTechInfo: () => {
+    dispatch(showModal({ modalType: 'TECHINFO' }))
+  },
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(AccountScreen)
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Address #27 

This info could eventually be anything: version number, author contact info, etc. Right now, we're just showing what we need in order to make life easier for us devs:

- Show url of Bookit API

- Show the nonce. Note that this is not the nonce we use to contruct the MS Auth Url.

- Show the session id, which is different every time you launch the app. See: https://docs.expo.io/versions/latest/sdk/constants.html#expoconstantssessionid

Also in this commit:

Add TechInfoModal and accompanying snapshot test.

Add a component for labels. This should be used wherever we have a label.

Add snapshot tests for styled text components